### PR TITLE
Support extension headers

### DIFF
--- a/client/auth_rep.go
+++ b/client/auth_rep.go
@@ -15,7 +15,7 @@ import (
 const authRepEndpoint = "/transactions/authrep.xml"
 
 //AuthRep - Authorize & Report for the Application Id authentication pattern
-func (client *ThreeScaleClient) AuthRepAppID(auth TokenAuth, appId string, serviceId string, params AuthRepParams) (ApiResponse, error) {
+func (client *ThreeScaleClient) AuthRepAppID(auth TokenAuth, appId string, serviceId string, params AuthRepParams, extensions map[string]string) (ApiResponse, error) {
 	values := parseQueries(params, url.Values{}, params.Metrics, params.Log)
 	values.Add("app_id", appId)
 	values.Add("service_id", serviceId)
@@ -25,11 +25,11 @@ func (client *ThreeScaleClient) AuthRepAppID(auth TokenAuth, appId string, servi
 		return ApiResponse{}, err
 	}
 
-	return client.authRep(values)
+	return client.authRep(values, extensions)
 }
 
 //AuthRepKey - Authorize & Report for the API Key authentication pattern with service token
-func (client *ThreeScaleClient) AuthRepUserKey(auth TokenAuth, userKey string, serviceId string, params AuthRepParams) (ApiResponse, error) {
+func (client *ThreeScaleClient) AuthRepUserKey(auth TokenAuth, userKey string, serviceId string, params AuthRepParams, extensions map[string]string) (ApiResponse, error) {
 	values := parseQueries(params, url.Values{}, params.Metrics, params.Log)
 	values.Add("user_key", userKey)
 	values.Add("service_id", serviceId)
@@ -39,13 +39,13 @@ func (client *ThreeScaleClient) AuthRepUserKey(auth TokenAuth, userKey string, s
 		return ApiResponse{}, err
 	}
 
-	return client.authRep(values)
+	return client.authRep(values, extensions)
 }
 
-func (client *ThreeScaleClient) authRep(values url.Values) (ApiResponse, error) {
+func (client *ThreeScaleClient) authRep(values url.Values, extensions map[string]string) (ApiResponse, error) {
 	var resp ApiResponse
 
-	req, err := client.buildGetReq(authRepEndpoint, nil)
+	req, err := client.buildGetReq(authRepEndpoint, extensions)
 	if err != nil {
 		return resp, errors.New(httpReqError.Error() + " for AuthRep")
 	}

--- a/client/auth_rep.go
+++ b/client/auth_rep.go
@@ -45,7 +45,7 @@ func (client *ThreeScaleClient) AuthRepUserKey(auth TokenAuth, userKey string, s
 func (client *ThreeScaleClient) authRep(values url.Values) (ApiResponse, error) {
 	var resp ApiResponse
 
-	req, err := client.buildGetReq(authRepEndpoint)
+	req, err := client.buildGetReq(authRepEndpoint, nil)
 	if err != nil {
 		return resp, errors.New(httpReqError.Error() + " for AuthRep")
 	}

--- a/client/auth_rep_test.go
+++ b/client/auth_rep_test.go
@@ -30,6 +30,7 @@ func TestAuthRep(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -42,6 +43,7 @@ func TestAuthRep(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -56,6 +58,12 @@ func TestAuthRep(t *testing.T) {
 			params := req.URL.Query()
 			if input.expectParamLength != len(params) {
 				t.Fatalf("unexpected param length, expect %d got  %d", input.expectParamLength, len(params))
+			}
+
+			if input.extensions != nil {
+				if ok, err := checkExtensions(req); !ok {
+					t.Fatal(err)
+				}
 			}
 
 			queryAppId := params["app_id"][0]
@@ -118,6 +126,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -130,6 +139,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -142,6 +152,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: "invalid",
 			},
+			extensions:        getExtensions(),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -155,6 +166,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -168,6 +180,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectReason:      "user_key_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -181,6 +194,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -197,6 +211,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     false,
 			expectStatus:      409,
 			expectParamLength: 4,
@@ -214,6 +229,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -227,6 +243,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 9,
@@ -246,6 +263,12 @@ func TestAuthRepKey(t *testing.T) {
 			params := req.URL.Query()
 			if input.expectParamLength != len(params) {
 				t.Fatalf("unexpected param length, expect %d got  %d", input.expectParamLength, len(params))
+			}
+
+			if input.extensions != nil {
+				if ok, err := checkExtensions(req); !ok {
+					t.Fatal(err)
+				}
 			}
 
 			queryUserKey := params["user_key"][0]

--- a/client/auth_rep_test.go
+++ b/client/auth_rep_test.go
@@ -15,6 +15,7 @@ func TestAuthRep(t *testing.T) {
 	authRepInputs := []struct {
 		appId, svcId      string
 		auth              TokenAuth
+		extensions        map[string]string
 		expectErr         bool
 		expectSuccess     bool
 		expectReason      string
@@ -74,7 +75,7 @@ func TestAuthRep(t *testing.T) {
 			}
 		})
 		c := threeScaleTestClient(httpClient)
-		resp, err := c.AuthRepAppID(input.auth, input.appId, input.svcId, input.buildParams())
+		resp, err := c.AuthRepAppID(input.auth, input.appId, input.svcId, input.buildParams(), input.extensions)
 		if input.expectErr && err != nil {
 			continue
 		}
@@ -102,6 +103,7 @@ func TestAuthRepKey(t *testing.T) {
 	authRepInputs := []struct {
 		userKey, svcId    string
 		auth              TokenAuth
+		extensions        map[string]string
 		expectErr         bool
 		expectSuccess     bool
 		expectReason      string
@@ -301,7 +303,7 @@ func TestAuthRepKey(t *testing.T) {
 		})
 
 		c := threeScaleTestClient(httpClient)
-		resp, err := c.AuthRepUserKey(input.auth, input.userKey, input.svcId, input.buildParams())
+		resp, err := c.AuthRepUserKey(input.auth, input.userKey, input.svcId, input.buildParams(), input.extensions)
 		if input.expectErr && err != nil {
 			continue
 		}

--- a/client/authz.go
+++ b/client/authz.go
@@ -9,10 +9,10 @@ import (
 const authzEndpoint = "/transactions/authorize.xml"
 
 //Authorize - Read-only operation to authorize an application in the App Id authentication pattern.
-func (client *ThreeScaleClient) Authorize(appId string, serviceToken string, serviceId string, arp AuthorizeParams) (ApiResponse, error) {
+func (client *ThreeScaleClient) Authorize(appId string, serviceToken string, serviceId string, arp AuthorizeParams, extensions map[string]string) (ApiResponse, error) {
 	var authRepResp ApiResponse
 
-	req, err := client.buildGetReq(authzEndpoint, nil)
+	req, err := client.buildGetReq(authzEndpoint, extensions)
 	if err != nil {
 		return authRepResp, errors.New(httpReqError.Error() + " for Authorize")
 	}
@@ -31,10 +31,10 @@ func (client *ThreeScaleClient) Authorize(appId string, serviceToken string, ser
 }
 
 //Authorize -  Read-only operation to authorize an application for the API Key authentication pattern
-func (client *ThreeScaleClient) AuthorizeKey(userKey string, serviceToken string, serviceId string, arp AuthorizeKeyParams) (ApiResponse, error) {
+func (client *ThreeScaleClient) AuthorizeKey(userKey string, serviceToken string, serviceId string, arp AuthorizeKeyParams, extensions map[string]string) (ApiResponse, error) {
 	var resp ApiResponse
 
-	req, err := client.buildGetReq(authzEndpoint, nil)
+	req, err := client.buildGetReq(authzEndpoint, extensions)
 	if err != nil {
 		return resp, errors.New(httpReqError.Error() + " for AuthRepKey")
 	}

--- a/client/authz.go
+++ b/client/authz.go
@@ -12,7 +12,7 @@ const authzEndpoint = "/transactions/authorize.xml"
 func (client *ThreeScaleClient) Authorize(appId string, serviceToken string, serviceId string, arp AuthorizeParams) (ApiResponse, error) {
 	var authRepResp ApiResponse
 
-	req, err := client.buildGetReq(authzEndpoint)
+	req, err := client.buildGetReq(authzEndpoint, nil)
 	if err != nil {
 		return authRepResp, errors.New(httpReqError.Error() + " for Authorize")
 	}
@@ -34,7 +34,7 @@ func (client *ThreeScaleClient) Authorize(appId string, serviceToken string, ser
 func (client *ThreeScaleClient) AuthorizeKey(userKey string, serviceToken string, serviceId string, arp AuthorizeKeyParams) (ApiResponse, error) {
 	var resp ApiResponse
 
-	req, err := client.buildGetReq(authzEndpoint)
+	req, err := client.buildGetReq(authzEndpoint, nil)
 	if err != nil {
 		return resp, errors.New(httpReqError.Error() + " for AuthRepKey")
 	}

--- a/client/authz_test.go
+++ b/client/authz_test.go
@@ -26,6 +26,7 @@ func TestAuthorize(t *testing.T) {
 			appId:             fakeAppId,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -35,6 +36,7 @@ func TestAuthorize(t *testing.T) {
 			appId:             "failme",
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -45,6 +47,7 @@ func TestAuthorize(t *testing.T) {
 			appId:             fakeAppId,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 6,
@@ -62,6 +65,12 @@ func TestAuthorize(t *testing.T) {
 			params := req.URL.Query()
 			if input.expectParamLength != len(params) {
 				t.Fatalf("unexpected param length, expect %d got  %d", input.expectParamLength, len(params))
+			}
+
+			if input.extensions != nil {
+				if ok, err := checkExtensions(req); !ok {
+					t.Fatal(err)
+				}
 			}
 
 			queryAppId := params["app_id"][0]
@@ -120,6 +129,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -129,6 +139,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -138,6 +149,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          "invalid",
+			extensions:        getExtensions(),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -148,6 +160,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             "invalid",
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -158,6 +171,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           "invalid",
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectReason:      "user_key_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -168,6 +182,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -181,6 +196,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     false,
 			expectStatus:      409,
 			expectParamLength: 4,
@@ -195,6 +211,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           "failme",
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -205,6 +222,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 6,
@@ -223,6 +241,12 @@ func TestAuthorizeKey(t *testing.T) {
 			params := req.URL.Query()
 			if input.expectParamLength != len(params) {
 				t.Fatalf("unexpected param length, expect %d got  %d", input.expectParamLength, len(params))
+			}
+
+			if input.extensions != nil {
+				if ok, err := checkExtensions(req); !ok {
+					t.Fatal(err)
+				}
 			}
 
 			queryUserKey := params["user_key"][0]

--- a/client/authz_test.go
+++ b/client/authz_test.go
@@ -14,6 +14,7 @@ func TestAuthorize(t *testing.T) {
 	fakeAppId, fakeServiceToken, fakeServiceId := "appId12345", "servicetoken54321", "555000"
 	authInputs := []struct {
 		appId, svcToken, svcId string
+		extensions             map[string]string
 		expectErr              bool
 		expectSuccess          bool
 		expectReason           string
@@ -80,7 +81,7 @@ func TestAuthorize(t *testing.T) {
 			}
 		})
 		c := threeScaleTestClient(httpClient)
-		resp, err := c.Authorize(input.appId, input.svcToken, input.svcId, input.buildParams())
+		resp, err := c.Authorize(input.appId, input.svcToken, input.svcId, input.buildParams(), input.extensions)
 		if input.expectErr && err != nil {
 			continue
 		}
@@ -107,6 +108,7 @@ func TestAuthorizeKey(t *testing.T) {
 	fakeMetricKey := "usage[hits]"
 	authRepInputs := []struct {
 		userKey, svcToken, svcId string
+		extensions               map[string]string
 		expectErr                bool
 		expectSuccess            bool
 		expectReason             string
@@ -278,7 +280,7 @@ func TestAuthorizeKey(t *testing.T) {
 		})
 
 		c := threeScaleTestClient(httpClient)
-		resp, err := c.AuthorizeKey(input.userKey, input.svcToken, input.svcId, input.buildParams())
+		resp, err := c.AuthorizeKey(input.userKey, input.svcToken, input.svcId, input.buildParams(), input.extensions)
 		if input.expectErr && err != nil {
 			continue
 		}

--- a/client/report.go
+++ b/client/report.go
@@ -10,7 +10,7 @@ import (
 const reportEndpoint = "/transactions.xml"
 
 //ReportAppID - Report for the Application Id authentication pattern with serviceToken
-func (client *ThreeScaleClient) ReportAppID(auth TokenAuth, serviceId string, transactions ReportTransactions) (ApiResponse, error) {
+func (client *ThreeScaleClient) ReportAppID(auth TokenAuth, serviceId string, transactions ReportTransactions, extensions map[string]string) (ApiResponse, error) {
 	values := parseQueries(transactions, url.Values{}, transactions.Metrics, transactions.Log)
 
 	err := auth.SetURLValues(&values)
@@ -21,11 +21,11 @@ func (client *ThreeScaleClient) ReportAppID(auth TokenAuth, serviceId string, tr
 	values.Add("service_id", serviceId)
 	log.Errorf("%#v", values)
 
-	return client.report(values)
+	return client.report(values, extensions)
 }
 
 //ReportUserKey - Report for the API Key authentication pattern with service token
-func (client *ThreeScaleClient) ReportUserKey(auth TokenAuth, serviceId string, transactions ReportTransactions) (ApiResponse, error) {
+func (client *ThreeScaleClient) ReportUserKey(auth TokenAuth, serviceId string, transactions ReportTransactions, extensions map[string]string) (ApiResponse, error) {
 	values := parseQueries(transactions, url.Values{}, transactions.Metrics, transactions.Log)
 
 	err := auth.SetURLValues(&values)
@@ -34,13 +34,13 @@ func (client *ThreeScaleClient) ReportUserKey(auth TokenAuth, serviceId string, 
 	}
 
 	values.Add("service_id", serviceId)
-	return client.report(values)
+	return client.report(values, extensions)
 }
 
-func (client *ThreeScaleClient) report(values url.Values) (ApiResponse, error) {
+func (client *ThreeScaleClient) report(values url.Values, extensions map[string]string) (ApiResponse, error) {
 	var resp ApiResponse
 
-	req, err := client.buildGetReq(reportEndpoint, nil)
+	req, err := client.buildGetReq(reportEndpoint, extensions)
 	if err != nil {
 		return resp, errors.New(httpReqError.Error() + " for report")
 	}

--- a/client/report.go
+++ b/client/report.go
@@ -40,7 +40,7 @@ func (client *ThreeScaleClient) ReportUserKey(auth TokenAuth, serviceId string, 
 func (client *ThreeScaleClient) report(values url.Values) (ApiResponse, error) {
 	var resp ApiResponse
 
-	req, err := client.buildGetReq(reportEndpoint)
+	req, err := client.buildGetReq(reportEndpoint, nil)
 	if err != nil {
 		return resp, errors.New(httpReqError.Error() + " for report")
 	}

--- a/client/report_test.go
+++ b/client/report_test.go
@@ -30,6 +30,7 @@ func TestReportAppID(t *testing.T) {
 		{
 			svcId:             fakeServiceId,
 			auth:              auth,
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 5,
@@ -46,6 +47,7 @@ func TestReportAppID(t *testing.T) {
 				Type:  "service_token",
 				Value: "servicetoken54321",
 			},
+			extensions:        getExtensions(),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -57,6 +59,7 @@ func TestReportAppID(t *testing.T) {
 				Type:  "service_token",
 				Value: "servicetoken54321",
 			},
+			extensions:        getExtensions(),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -70,6 +73,12 @@ func TestReportAppID(t *testing.T) {
 			params := req.URL.Query()
 			if input.expectParamLength != len(params) {
 				t.Fatalf("unexpected param length, expect %d got  %d", input.expectParamLength, len(params))
+			}
+
+			if input.extensions != nil {
+				if ok, err := checkExtensions(req); !ok {
+					t.Fatal(err)
+				}
 			}
 
 			queryAppId := params["app_id"][0]

--- a/client/report_test.go
+++ b/client/report_test.go
@@ -19,6 +19,7 @@ func TestReportAppID(t *testing.T) {
 	authInputs := []struct {
 		svcId             string
 		auth              TokenAuth
+		extensions        map[string]string
 		expectErr         bool
 		expectSuccess     bool
 		expectReason      string
@@ -88,7 +89,7 @@ func TestReportAppID(t *testing.T) {
 			}
 		})
 		c := threeScaleTestClient(httpClient)
-		resp, err := c.ReportAppID(input.auth, input.svcId, input.buildParams())
+		resp, err := c.ReportAppID(input.auth, input.svcId, input.buildParams(), input.extensions)
 		if input.expectErr && err != nil {
 			continue
 		}


### PR DESCRIPTION
This adds support for [Apisonator's Extensions](https://github.com/3scale/apisonator/blob/v2.89.0/docs/rfcs/api-extensions.md) (see also [documented extensions](https://github.com/3scale/apisonator/blob/v2.89.0/docs/extensions.md)). This allows users to take advantage of newer or experimental features in apisonator, especially those related to performance and optimization (ie. caching) and any other new features that could land to support specific use cases.

The extensions are passed in as a map of strings (extension names/keys) to strings (values).

This breaks the API for users by adding a new parameter.