### PR TITLE
test: mark helpers as such with t.Helper()

### DIFF
--- a/client/auth_rep_test.go
+++ b/client/auth_rep_test.go
@@ -30,7 +30,7 @@ func TestAuthRep(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -43,7 +43,7 @@ func TestAuthRep(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -61,7 +61,7 @@ func TestAuthRep(t *testing.T) {
 			}
 
 			if input.extensions != nil {
-				if ok, err := checkExtensions(req); !ok {
+				if ok, err := checkExtensions(t, req); !ok {
 					t.Fatal(err)
 				}
 			}
@@ -126,7 +126,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -139,7 +139,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -152,7 +152,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: "invalid",
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -166,7 +166,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -180,7 +180,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectReason:      "user_key_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -194,7 +194,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -211,7 +211,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     false,
 			expectStatus:      409,
 			expectParamLength: 4,
@@ -229,7 +229,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -243,7 +243,7 @@ func TestAuthRepKey(t *testing.T) {
 				Type:  serviceToken,
 				Value: fakeServiceToken,
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 9,
@@ -266,7 +266,7 @@ func TestAuthRepKey(t *testing.T) {
 			}
 
 			if input.extensions != nil {
-				if ok, err := checkExtensions(req); !ok {
+				if ok, err := checkExtensions(t, req); !ok {
 					t.Fatal(err)
 				}
 			}

--- a/client/authz_test.go
+++ b/client/authz_test.go
@@ -26,7 +26,7 @@ func TestAuthorize(t *testing.T) {
 			appId:             fakeAppId,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -36,7 +36,7 @@ func TestAuthorize(t *testing.T) {
 			appId:             "failme",
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -47,7 +47,7 @@ func TestAuthorize(t *testing.T) {
 			appId:             fakeAppId,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 6,
@@ -68,7 +68,7 @@ func TestAuthorize(t *testing.T) {
 			}
 
 			if input.extensions != nil {
-				if ok, err := checkExtensions(req); !ok {
+				if ok, err := checkExtensions(t, req); !ok {
 					t.Fatal(err)
 				}
 			}
@@ -129,7 +129,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -139,7 +139,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -149,7 +149,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          "invalid",
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -160,7 +160,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             "invalid",
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectReason:      "service_token_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -171,7 +171,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           "invalid",
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectReason:      "user_key_invalid",
 			expectSuccess:     false,
 			expectStatus:      403,
@@ -182,7 +182,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 4,
@@ -196,7 +196,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     false,
 			expectStatus:      409,
 			expectParamLength: 4,
@@ -211,7 +211,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           "failme",
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -222,7 +222,7 @@ func TestAuthorizeKey(t *testing.T) {
 			userKey:           fakeUserKey,
 			svcId:             fakeServiceId,
 			svcToken:          fakeServiceToken,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 6,
@@ -244,7 +244,7 @@ func TestAuthorizeKey(t *testing.T) {
 			}
 
 			if input.extensions != nil {
-				if ok, err := checkExtensions(req); !ok {
+				if ok, err := checkExtensions(t, req); !ok {
 					t.Fatal(err)
 				}
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -85,7 +85,9 @@ func equals(tb testing.TB, exp, act interface{}) {
 	}
 }
 
-func getExtensions() map[string]string {
+func getExtensions(t *testing.T) map[string]string {
+	t.Helper()
+
 	// ensure we at least return the extensions the first time we get called
 	if !ext_tested || rand.Intn(2) != 0 {
 		ext_tested = true
@@ -118,7 +120,9 @@ func getExtensionsValue() []string {
 	return exp
 }
 
-func checkExtensions(req *http.Request) (bool, string) {
+func checkExtensions(t *testing.T, req *http.Request) (bool, string) {
+	t.Helper()
+
 	value := req.Header.Get("3scale-options")
 	expected := getExtensionsValue()
 

--- a/client/report_test.go
+++ b/client/report_test.go
@@ -30,7 +30,7 @@ func TestReportAppID(t *testing.T) {
 		{
 			svcId:             fakeServiceId,
 			auth:              auth,
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 5,
@@ -47,7 +47,7 @@ func TestReportAppID(t *testing.T) {
 				Type:  "service_token",
 				Value: "servicetoken54321",
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectSuccess:     true,
 			expectStatus:      200,
 			expectParamLength: 3,
@@ -59,7 +59,7 @@ func TestReportAppID(t *testing.T) {
 				Type:  "service_token",
 				Value: "servicetoken54321",
 			},
-			extensions:        getExtensions(),
+			extensions:        getExtensions(t),
 			expectErr:         true,
 			expectSuccess:     false,
 			expectStatus:      200,
@@ -76,7 +76,7 @@ func TestReportAppID(t *testing.T) {
 			}
 
 			if input.extensions != nil {
-				if ok, err := checkExtensions(req); !ok {
+				if ok, err := checkExtensions(t, req); !ok {
 					t.Fatal(err)
 				}
 			}


### PR DESCRIPTION
It is best practice to mark the test helpers as such.

This is only done in entry points for helpers used directly in tests
but not for the funcs private to the helpers themselves.

@PhilipGough is just marking the helpers called directly by the test code enough or does this also need to be applied to private functions called within the helpers? I assume the latter is a no.