### PR TITLE
Removes log statement

### DIFF
--- a/client/report.go
+++ b/client/report.go
@@ -3,7 +3,6 @@ package client
 import (
 	"errors"
 	"fmt"
-	"istio.io/istio/pkg/log"
 	"net/url"
 )
 
@@ -19,7 +18,6 @@ func (client *ThreeScaleClient) ReportAppID(auth TokenAuth, serviceId string, tr
 	}
 
 	values.Add("service_id", serviceId)
-	log.Errorf("%#v", values)
 
 	return client.report(values, extensions)
 }


### PR DESCRIPTION
A third party logger was introduced into the client creating a dependency that went unnoticed. If we need logging in the client we would likely want it to be injected. This change removes it for now and the caller can log the error if required.