### PR TITLE
bug: Fixes out of bounds error when parsing limit headers.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -118,7 +118,7 @@ func (client *ThreeScaleClient) doHttpReq(req *http.Request, ext map[string]stri
 	if ext != nil {
 		if _, ok := ext[limitExtensions]; ok {
 			authRepRes.RateLimits = &RateLimits{}
-			if limitRem := resp.Header[limitRemainingHeaderKey][0]; limitRem != "" {
+			if limitRem := resp.Header.Get(limitRemainingHeaderKey); limitRem != "" {
 				remainingLimit, err := strconv.Atoi(limitRem)
 				if err != nil {
 					authRepRes.RateLimits = nil
@@ -127,7 +127,7 @@ func (client *ThreeScaleClient) doHttpReq(req *http.Request, ext map[string]stri
 				authRepRes.RateLimits.limitRemaining = remainingLimit
 			}
 
-			if limReset := resp.Header[limitResetHeaderKey][0]; limReset != "" {
+			if limReset := resp.Header.Get(limitResetHeaderKey); limReset != "" {
 				resetLimit, err := strconv.Atoi(limReset)
 				if err != nil {
 					authRepRes.RateLimits = nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -136,7 +136,8 @@ func TestExtensions(t *testing.T) {
 					t.Errorf("unexpected limit parsing - limit reset")
 				}
 			},
-			headers: http.Header{limitRemainingHeaderKey: []string{"10"}, limitResetHeaderKey: []string{"500"}},
+			headers: http.Header{http.CanonicalHeaderKey(limitRemainingHeaderKey): []string{"10"},
+				http.CanonicalHeaderKey(limitResetHeaderKey): []string{"500"}},
 		},
 	}
 	for _, input := range inputs {


### PR DESCRIPTION
The test failed to show an error that revealed itself when the client was integrated with 3scale backend.

Solution is to use the canonical format for the header key and adapt the test to reflect this.