### PR TITLE
Adds a generic wrapper around AuthRep API

### DIFF
--- a/client/auth_rep.go
+++ b/client/auth_rep.go
@@ -14,7 +14,20 @@ import (
 
 const authRepEndpoint = "/transactions/authrep.xml"
 
-//AuthRep - Authorize & Report for the Application Id authentication pattern
+// AuthRep - Wrapper function to allow the client to determine, by parsing the provided data, what 3scale API should be called.
+// Note if both application types are provided then user_key authentication is prioritised.
+func (client *ThreeScaleClient) AuthRep(req Request, serviceId string, params AuthRepParams, extensions map[string]string) (ApiResponse, error) {
+	if req.Application.UserKey != "" {
+		return client.AuthRepUserKey(req.Credentials, req.Application.UserKey, serviceId, params, extensions)
+	}
+
+	if appKey := req.Application.AppID.AppKey; appKey != "" {
+		params.AppKey = appKey
+	}
+	return client.AuthRepAppID(req.Credentials, req.Application.AppID.ID, serviceId, params, extensions)
+}
+
+//AuthRepAppID - Authorize & Report for the Application Id authentication pattern
 func (client *ThreeScaleClient) AuthRepAppID(auth TokenAuth, appId string, serviceId string, params AuthRepParams, extensions map[string]string) (ApiResponse, error) {
 	values := parseQueries(params, url.Values{}, params.Metrics, params.Log)
 	values.Add("app_id", appId)

--- a/client/client.go
+++ b/client/client.go
@@ -201,6 +201,21 @@ func (l Log) convert() map[string]string {
 	return formatted
 }
 
+func (auth *TokenAuth) SetURLValues(values *url.Values) error {
+	switch auth.Type {
+	case serviceToken:
+		values.Add("service_token", auth.Value)
+		return nil
+
+	case providerKey:
+		values.Add("provider_key", auth.Value)
+		return nil
+
+	default:
+		return errors.New("invalid token type value")
+	}
+}
+
 // Verifies a custom backend is valid
 func verifyBackendUrl(urlToCheck string) (*url.URL, error) {
 	url2, err := url.ParseRequestURI(urlToCheck)

--- a/client/types.go
+++ b/client/types.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/xml"
-	"errors"
 	"net/http"
 	"net/url"
 )
@@ -98,19 +97,18 @@ type RateLimits struct {
 	limitReset     int
 }
 
-func (auth *TokenAuth) SetURLValues(values *url.Values) error {
+type AppID struct {
+	ID string
+	//Optional AppKey
+	AppKey string
+}
 
-	switch auth.Type {
-	case serviceToken:
-		values.Add("service_token", auth.Value)
-		return nil
+type Application struct {
+	AppID   AppID
+	UserKey string
+}
 
-	case providerKey:
-		values.Add("provider_key", auth.Value)
-		return nil
-
-	default:
-		return errors.New("invalid token type value")
-	}
-
+type Request struct {
+	Application Application
+	Credentials TokenAuth
 }


### PR DESCRIPTION
This change allows users of this client to call AuthRep with some data and have the function
determine internally what endpoint should be called.