### PR TITLE
bug: Fix potential panic on error when calling backend

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -107,11 +107,11 @@ func (client *ThreeScaleClient) doHttpReq(req *http.Request, ext map[string]stri
 	var authRepRes ApiResponse
 
 	resp, err := client.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return authRepRes, err
 	}
+
+	defer resp.Body.Close()
 
 	authRepRes, err = getApiResp(resp.Body)
 


### PR DESCRIPTION
Defer should be called after error is checked to avoid calling function on nil.

Exposed via https://github.com/3scale/3scale-istio-adapter/issues/81