### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## 3Scale Service Management API Client
 
+[![CircleCI](https://circleci.com/gh/3scale/3scale-go-client/tree/master.svg?style=svg)](https://circleci.com/gh/3scale/3scale-go-client/tree/master)
+[![Go Report](https://goreportcard.com/badge/github.com/3scale/3scale-go-client)](https://goreportcard.com/badge/github.com/3scale/3scale-go-client)
+[![GoDoc](https://godoc.org/github.com/3scale/3scale-go-client/threescale?status.svg)](https://godoc.org/github.com/3scale/3scale-go-client/threescale)
+[![codecov.io](http://codecov.io/github/3scale/3scale-go-client/coverage.svg?branch=master)](http://codecov.io/github/3scale/3scale-go-client?branch=master)
+
 **Note: This project is in _alpha_ and is currently unsupported.**
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -2,70 +2,10 @@
 
 **Note: This project is in _alpha_ and is currently unsupported.**
 
-### Creating a client
+### Documentation
 
-A 3scale client can be configured with the default backend, which points to `https://su1.3scale.net:443`. Alternatively, a custom backend can be configured.
-The 3scale client can be provided with a custom [HTTP client](https://golang.org/pkg/net/http/?#Client). If none is provided (not recommended), the default client will be used.
+For documentation, see https://godoc.org/github.com/3scale/3scale-go-client/threescale
 
-A client can be created for the default 3scale backend, which points to `"https://su1.3scale.net:443`
+### Testing
 
-```go
-	client := NewThreeScale(DefaultBackend(), &http.Client{
-	        Timeout: 30 * time.Second,
-        })
-
-```
-
-### Calling the Authorize endpoint
-
-The client supports calling the `Authorize` endpoint using both the **_Application ID_** and **_Application Key_** authentication patterns. Metrics can be added as well as optional
-parameters for both API's.
-
-```go
-        // App Id Pattern - No optional params
-	resp, err := c.Authorize("myAppId", "mySvcToken", "myServiceId", AuthorizeParams{})
-	if err != nil {
-		// Handle error
-	}
-	if !resp.Success {
-		fmt.Printf("request failed - reason: %s", resp.Reason)
-	}
-	
-	// App Id pattern with optional params and metrics
-	p := NewAuthorizeParams("myAppKey", "exampleReferrer", "")
-	p.Metrics.Add("hits", 1)
-	resp, _ = c.Authorize("myAppId", "mySvcToken", "myServiceId", p)
-	
-	// App key pattern with optional params
-	p = NewAuthorizeKeyParams("exampleRef", "exampleId")
-	resp, _ = c.AuthorizeKey("userKey", "svcToken", "svcID", p)
-	
-```
-
-### Calling the AuthRep endpoint
-
-The client supports calling the `AuthRep` endpoint using both the **_Application ID_** and **_Application Key_** authentication patterns. Metrics and Log can be added as well as optional
-parameters for both API's.
-
-```go
-	client := NewThreeScale(nil, nil)
-	// App Id Pattern - No optional params
-	resp, err := client.AuthRep("myAppId", "mySvcToken", "myServiceId", AuthRepParams{})
-	if err != nil {
-		// Handle error
-	}
-	if !resp.Success {
-		fmt.Printf("request failed - reason: %s", resp.Reason)
-	}
-
-	// App Id pattern with optional params and metrics
-	p := NewAuthRepParams("myAppKey", "exampleReferrer", "")
-	p.Metrics.Add("hits", 1)
-	p.Log.Set("exampleReq", "exampleResp", 200)
-	resp, _ = client.AuthRep("myAppId", "mySvcToken", "myServiceId", p)
-
-	// App key pattern with optional params
-	pms := NewAuthRepKeyParams("exampleRef", "exampleId")
-	resp, _ = client.AuthRepKey("userKey", "svcToken", "svcID", pms)
-	
-```
+To run the unit tests, run `make test` from the project root.

--- a/fake/xml_resp.go
+++ b/fake/xml_resp.go
@@ -2,7 +2,7 @@ package fake
 
 import "fmt"
 
-// Get default success response for authorize endpoint
+// GetAuthSuccess gets default success response for authorize endpoint
 func GetAuthSuccess() string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <status>
@@ -11,25 +11,25 @@ func GetAuthSuccess() string {
 </status>`
 }
 
-// Get mock response for invalid service token or id
+// GenInvalidIdOrTokenResp gets mock response for invalid service token or id
 func GenInvalidIdOrTokenResp(token string, id string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <error code="service_token_invalid">service token "%s" or service id "%s" is invalid</error>`, token, id)
 }
 
-// Get mock response for invalid metric
+// GetInvalidMetricResp gets mock response for invalid metric
 func GetInvalidMetricResp() string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <error code="metric_invalid">metric "anyButHits" is invalid</error>`
 }
 
-// Get mock response for invalid user key
+// GenInvalidUserKey gets mock response for invalid user key
 func GenInvalidUserKey(key string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <error code="user_key_invalid">user key "%s" is invalid</error>`, key)
 }
 
-// Get mock response for limit exceeded
+// GetLimitExceededResp gets mock response for limit exceeded
 func GetLimitExceededResp() string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <status>
@@ -47,7 +47,7 @@ func GetLimitExceededResp() string {
 </status>`
 }
 
-// Get mock response with hierarchy extension enabled
+// GetHierarchyEnabledResponse gets mock response with hierarchy extension enabled
 func GetHierarchyEnabledResponse() string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <status>

--- a/threescale/api.go
+++ b/threescale/api.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	httpReqError = errors.New(httpReqErrText)
+	errHttpReq = errors.New(httpReqErrText)
 )
 
 // Authorize is a read-only operation to authorize an application with the authentication provided in the transaction params
@@ -46,7 +46,7 @@ func (c *Client) authOrAuthRep(endpoint, serviceID string, auth ClientAuth, tran
 	// build out http transaction for the provided Transaction object
 	req, err := c.buildGetReq(c.baseURL+endpoint, options)
 	if err != nil {
-		return nil, fmt.Errorf("%s - %s ", httpReqError.Error(), err.Error())
+		return nil, fmt.Errorf("%s - %s ", errHttpReq.Error(), err.Error())
 	}
 	// take the user input and encode to query string formatted to the expectations of 3scale backend
 	req.URL.RawQuery = c.inputToValues(serviceID, transaction, auth).Encode()
@@ -113,7 +113,7 @@ func (c *Client) doAuthorizeReq(req *http.Request, extensions Extensions) (*Auth
 func (c *Client) doReportReq(values url.Values, options *Options) (*ReportResponse, error) {
 	req, err := http.NewRequest(http.MethodPost, c.baseURL+reportEndpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("%s - %s ", httpReqError.Error(), err.Error())
+		return nil, fmt.Errorf("%s - %s ", errHttpReq.Error(), err.Error())
 	}
 
 	req = c.annotateRequest(req, options)

--- a/threescale/api_test.go
+++ b/threescale/api_test.go
@@ -211,7 +211,7 @@ func TestClient_Authorize(t *testing.T) {
 			},
 			injectClient: NewTestClient(func(req *http.Request) *http.Response {
 				if strings.Contains(req.URL.RawQuery, "usage") {
-					t.Error("unexpected usage has been generated for emtpy transaction")
+					t.Error("unexpected usage has been generated for empty transaction")
 				}
 				expectValSet := req.Header.Get("3scale-Options")
 				if expectValSet != "limit_headers=1" {
@@ -581,9 +581,8 @@ func getExtensions(t *testing.T) map[string]string {
 			"many@@and==":   "should@@befine==",
 			"a test&":       "&ok",
 		}
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // returns a randomly-ordered list of strings for extensions with format "key=value"
@@ -615,15 +614,14 @@ func checkExtensions(t *testing.T, req *http.Request) (bool, string) {
 
 	if compareUnorderedStringLists(found, expected) {
 		return true, ""
-	} else {
-		sort.Strings(expected)
-		sort.Strings(found)
-
-		return false, fmt.Sprintf("\nexpected extension header value %s\n"+
-			"                      but found %s",
-			strings.Join(expected, ", "), strings.Join(found, ", "))
-
 	}
+	sort.Strings(expected)
+	sort.Strings(found)
+
+	return false, fmt.Sprintf("\nexpected extension header value %s\n"+
+		"                      but found %s",
+		strings.Join(expected, ", "), strings.Join(found, ", "))
+
 }
 
 func compareUnorderedStringLists(one []string, other []string) bool {

--- a/threescale/common.go
+++ b/threescale/common.go
@@ -187,17 +187,18 @@ func (ur UsageReportXML) convert() (UsageReport, error) {
 		CurrentValue: ur.CurrentValue,
 	}
 
-	if t, err := time.Parse(timeLayout, ur.PeriodStart); err != nil {
+	t, err := time.Parse(timeLayout, ur.PeriodStart)
+	if err != nil {
 		return report, err
-	} else {
-		report.PeriodStart = t.Unix()
 	}
+	report.PeriodStart = t.Unix()
 
-	if t, err := time.Parse(timeLayout, ur.PeriodEnd); err != nil {
+	t, err = time.Parse(timeLayout, ur.PeriodEnd)
+	if err != nil {
 		return report, err
-	} else {
-		report.PeriodEnd = t.Unix()
 	}
+	report.PeriodEnd = t.Unix()
+
 	return report, err
 }
 

--- a/threescale/common_test.go
+++ b/threescale/common_test.go
@@ -158,7 +158,7 @@ func TestMetrics_DeepCopy(t *testing.T) {
 	}
 
 	clone["test"] = 3
-	if v, ok = original["test"]; v != 2 {
+	if v, _ = original["test"]; v != 2 {
 		t.Error("unexpect value in original after modifying clone")
 	}
 }

--- a/threescale/options.go
+++ b/threescale/options.go
@@ -1,6 +1,8 @@
 package threescale
 
-import "context"
+import (
+	"context"
+)
 
 // WithContext wraps the http transaction to 3scale backend with the provided context
 func WithContext(ctx context.Context) Option {
@@ -9,7 +11,7 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
-// WithContext embeds the provided extensions in the http transaction to 3scale
+// WithExtensions embeds the provided extensions in the http transaction to 3scale
 // https://github.com/3scale/apisonator/blob/v2.96.2/docs/extensions.md
 func WithExtensions(extensions Extensions) Option {
 	return func(args *Options) {

--- a/threescale/types.go
+++ b/threescale/types.go
@@ -22,15 +22,14 @@ const (
 	// LimitExtension is the key to enable this extension when calling 3scale backend - set to 1 to enable
 	LimitExtension = "limit_headers"
 
-	// https://github.com/3scale/apisonator/issues/75
 	// HierarchyExtension is the key to enabling hierarchy feature. Set its bool value to 1 to enable.
+	// https://github.com/3scale/apisonator/issues/75
 	HierarchyExtension = "hierarchy"
 )
 
+// Predefined, known LimitPeriods which can be used in 3scale rate limiting functionality
+// These values represent time durations.
 const (
-
-	// Predefined, known LimitPeriods
-
 	Minute   LimitPeriod = "minute"
 	Hour     LimitPeriod = "hour"
 	Day      LimitPeriod = "day"
@@ -172,7 +171,7 @@ type ApiAuthResponseXML struct {
 	} `xml:"usage_reports"`
 }
 
-// Hierarchy encapsulates the return value when using "hierarchy" extension
+// HierarchyXML encapsulates the return value when using "hierarchy" extension
 type HierarchyXML struct {
 	Metric []struct {
 		Name     string `xml:"name,attr"`


### PR DESCRIPTION
This change removes the now deleted code from the readme and instead provides a link to go docs as our sole source of documentation.

Hopefully the package is simple enough to use at this point and documented enough that it is well explained.

Adds some badges to report project status