### PR TITLE
Metrics option

### DIFF
--- a/threescale/options.go
+++ b/threescale/options.go
@@ -19,9 +19,17 @@ func WithExtensions(extensions Extensions) Option {
 	}
 }
 
+// WithInstrumentationCallback allows the caller to provide an optional callback function that will
+// be called with the details of the underlying request to 3scale if present as an option
+func WithInstrumentationCallback(callback InstrumentationCB) Option {
+	return func(options *Options) {
+		options.instrumentationCB = callback
+	}
+}
+
 // newOptions for 3scale backend
 func newOptions(opts ...Option) *Options {
-	options := &Options{}
+	options := &Options{context: context.TODO()}
 
 	for _, opt := range opts {
 		opt(options)

--- a/threescale/types.go
+++ b/threescale/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"net/http"
+	"time"
 )
 
 const (
@@ -82,6 +83,10 @@ type Extensions map[string]string
 // Hierarchy maps a parent metric to its child metrics
 type Hierarchy map[string][]string
 
+// InstrumentationCB provides a callback hook into the client at response time to provide information
+// about the underlying request to the remote host
+type InstrumentationCB func(ctx context.Context, hostName, endpoint string, statusCode int, requestDuration time.Duration)
+
 // LimitPeriod wraps the known rate limiting periods as defined in 3scale
 type LimitPeriod string
 
@@ -93,8 +98,9 @@ type Option func(*Options)
 
 // Options to provide optional behaviour to the standard APIs for Authorize, AuthRep and Report
 type Options struct {
-	context    context.Context
-	extensions Extensions
+	context           context.Context
+	extensions        Extensions
+	instrumentationCB InstrumentationCB
 }
 
 // Params that are embedded in each Transaction to 3scale API


### PR DESCRIPTION
@unleashed - this change surfaces a hook for working with metrics via a callback. It pushes functionality that we have in the adapter (which is currently quiet unwieldly) into the client.

This will allow it to be used by others users of the client outside of the istio space and should help us with cleaning up the adapter code.