### PR TITLE
http: Parse error code/messge in http client

### DIFF
--- a/threescale/http/client.go
+++ b/threescale/http/client.go
@@ -174,12 +174,19 @@ func (c *Client) executeAuthCall(req *http.Request, extensions api.Extensions, o
 		}
 	}()
 
+	// because its non-deterministic where the error message should be retrieved from, we need to do this.
+	// for example when rate limits are exceeded it is set in 'Reason' but for most other errors it is set in 'Code'
+	var errCode = xmlResponse.Code
+	if errCode == "" {
+		errCode = xmlResponse.Reason
+	}
+
 	if err := xml.NewDecoder(resp.Body).Decode(&xmlResponse); err != nil {
 		return nil, err
 	}
 	response := &threescale.AuthorizeResult{
 		Authorized:          xmlResponse.Authorized,
-		ErrorCode:           xmlResponse.Code,
+		ErrorCode:           errCode,
 		AuthorizeExtensions: threescale.AuthorizeExtensions{},
 	}
 


### PR DESCRIPTION
This change works around the fact that the xml response may hold the
error messae which informs the user under different fields.