### PR TITLE
Propagate errs

### DIFF
--- a/threescale/http/client.go
+++ b/threescale/http/client.go
@@ -174,6 +174,10 @@ func (c *Client) executeAuthCall(req *http.Request, extensions api.Extensions, o
 		}
 	}()
 
+	if err := xml.NewDecoder(resp.Body).Decode(&xmlResponse); err != nil {
+		return nil, err
+	}
+
 	// because its non-deterministic where the error message should be retrieved from, we need to do this.
 	// for example when rate limits are exceeded it is set in 'Reason' but for most other errors it is set in 'Code'
 	var errCode = xmlResponse.Code
@@ -181,9 +185,6 @@ func (c *Client) executeAuthCall(req *http.Request, extensions api.Extensions, o
 		errCode = xmlResponse.Reason
 	}
 
-	if err := xml.NewDecoder(resp.Body).Decode(&xmlResponse); err != nil {
-		return nil, err
-	}
 	response := &threescale.AuthorizeResult{
 		Authorized:          xmlResponse.Authorized,
 		ErrorCode:           errCode,

--- a/threescale/http/client_test.go
+++ b/threescale/http/client_test.go
@@ -75,6 +75,56 @@ func TestClient_Authorize(t *testing.T) {
 			}),
 		},
 		{
+			name: "Test 3scale errors are propagated - invalid metric",
+			auth: api.ClientAuth{
+				Type:  api.ServiceToken,
+				Value: "any",
+			},
+			transaction: api.Transaction{
+				Params: api.Params{
+					AppID:  "any",
+					AppKey: "key",
+				},
+				Metrics: api.Metrics{"hits": 1, "other": 2},
+			},
+			expectResponse: &threescale.AuthorizeResult{
+				Authorized: false,
+				ErrorCode:  "metric_invalid",
+			},
+			injectClient: NewTestClient(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       ioutil.NopCloser(bytes.NewBufferString(fake.GetInvalidMetricResp())),
+					Header:     make(http.Header),
+				}
+			}),
+		},
+		{
+			name: "Test 3scale errors are propagated - invalid auth",
+			auth: api.ClientAuth{
+				Type:  api.ServiceToken,
+				Value: "any",
+			},
+			transaction: api.Transaction{
+				Params: api.Params{
+					AppID:  "any",
+					AppKey: "key",
+				},
+				Metrics: api.Metrics{"hits": 1, "other": 2},
+			},
+			expectResponse: &threescale.AuthorizeResult{
+				Authorized: false,
+				ErrorCode:  "user_key_invalid",
+			},
+			injectClient: NewTestClient(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       ioutil.NopCloser(bytes.NewBufferString(fake.GenInvalidUserKey("fake"))),
+					Header:     make(http.Header),
+				}
+			}),
+		},
+		{
 			name: "Test params formatting",
 			auth: api.ClientAuth{
 				Type:  api.ServiceToken,


### PR DESCRIPTION
This change fixes a bug that was assumed already fixed, however the variable was set before decoding so it needed to occur after decoding xml 🤦‍♂.

Adds test cases to correctly validate this for Auth and AuthRep