### PR TITLE
Add support for multiple usage reports per metric

### DIFF
--- a/threescale/api/types.go
+++ b/threescale/api/types.go
@@ -122,5 +122,5 @@ type UsageReport struct {
 	CurrentValue int
 }
 
-// UsageReports defines a map of metric names to 'UsageReport'
-type UsageReports map[string]UsageReport
+// UsageReports defines a map of metric names to a list of 'UsageReport'
+type UsageReports map[string][]UsageReport

--- a/threescale/http/client.go
+++ b/threescale/http/client.go
@@ -192,7 +192,7 @@ func (c *Client) executeAuthCall(req *http.Request, extensions api.Extensions, o
 	}
 
 	if reportLen := len(xmlResponse.UsageReports.Reports); reportLen > 0 {
-		response.UsageReports = c.convertXmlUsageReports(xmlResponse.UsageReports.Reports, reportLen)
+		response.UsageReports = c.convertXmlUsageReports(xmlResponse.UsageReports.Reports)
 	}
 
 	if extensions != nil {
@@ -254,12 +254,13 @@ func (c *Client) handleAuthExtensions(xmlResp internal.AuthResponseXML, resp *ht
 	return annotatedResp
 }
 
-func (c *Client) convertXmlUsageReports(xmlReports []internal.UsageReportXML, mapLen int) api.UsageReports {
-	usageReports := make(api.UsageReports, mapLen)
+func (c *Client) convertXmlUsageReports(xmlReports []internal.UsageReportXML) api.UsageReports {
+	usageReports := make(api.UsageReports)
 	for _, report := range xmlReports {
 		if converted, err := convertXmlToUsageReport(report); err == nil {
 			//nothing we can do here if we hit an error besides continue
-			usageReports[report.Metric] = converted
+			currentReports := usageReports[report.Metric]
+			usageReports[report.Metric] = append(currentReports, converted)
 		}
 	}
 	return usageReports

--- a/threescale/http/client_test.go
+++ b/threescale/http/client_test.go
@@ -191,23 +191,36 @@ func TestClient_Authorize(t *testing.T) {
 				Authorized: true,
 				AuthorizeExtensions: threescale.AuthorizeExtensions{
 					UsageReports: api.UsageReports{
-						"hits": api.UsageReport{
-							PeriodWindow: api.PeriodWindow{
-								Period: api.Minute,
-								Start:  1550845920,
-								End:    1550845980,
+						"hits": []api.UsageReport{
+							{
+								PeriodWindow: api.PeriodWindow{
+									Period: api.Minute,
+									Start:  1550845920,
+									End:    1550845980,
+								},
+								MaxValue:     4,
+								CurrentValue: 1,
 							},
-							MaxValue:     4,
-							CurrentValue: 1,
+							{
+								PeriodWindow: api.PeriodWindow{
+									Period: api.Hour,
+									Start:  1550844000,
+									End:    1550847599,
+								},
+								MaxValue:     40,
+								CurrentValue: 10,
+							},
 						},
-						"test_metric": api.UsageReport{
-							PeriodWindow: api.PeriodWindow{
-								Period: api.Week,
-								Start:  1550448000,
-								End:    1551052800,
+						"test_metric": []api.UsageReport{
+							{
+								PeriodWindow: api.PeriodWindow{
+									Period: api.Week,
+									Start:  1550448000,
+									End:    1551052800,
+								},
+								MaxValue:     6,
+								CurrentValue: 0,
 							},
-							MaxValue:     6,
-							CurrentValue: 0,
 						},
 					},
 				},
@@ -894,6 +907,12 @@ func getUsageReportXML(t *testing.T) string {
          <period_end>2019-02-22 14:33:00 +0000</period_end>
          <max_value>4</max_value>
          <current_value>1</current_value>
+      </usage_report>
+      <usage_report metric="hits" period="hour">
+         <period_start>2019-02-22 14:00:00 +0000</period_start>
+         <period_end>2019-02-22 14:59:59 +0000</period_end>
+         <max_value>40</max_value>
+         <current_value>10</current_value>
       </usage_report>
       <usage_report metric="test_metric" period="week">
          <period_start>2019-02-18 00:00:00 +0000</period_start>


### PR DESCRIPTION
Note: This is a breaking change but one that is required to ensure correctness for return values from 3scale
Fixes #37 