### PR TITLE
Adds sorting functionality to usage reports

### DIFF
--- a/threescale/api/types.go
+++ b/threescale/api/types.go
@@ -30,18 +30,18 @@ const (
 )
 
 // Period wraps the known rate limiting periods as defined in 3scale
-type Period string
+type Period int
 
 // Predefined, known LimitPeriods which can be used in 3scale rate limiting functionality
 // These values represent time durations.
 const (
-	Minute   Period = "minute"
-	Hour     Period = "hour"
-	Day      Period = "day"
-	Week     Period = "week"
-	Month    Period = "month"
-	Year     Period = "year"
-	Eternity Period = "eternity"
+	Minute Period = iota
+	Hour
+	Day
+	Week
+	Month
+	Year
+	Eternity
 )
 
 // AuthType maps to a known client authentication pattern

--- a/threescale/api/types.go
+++ b/threescale/api/types.go
@@ -40,6 +40,7 @@ const (
 	Day      Period = "day"
 	Week     Period = "week"
 	Month    Period = "month"
+	Year     Period = "year"
 	Eternity Period = "eternity"
 )
 

--- a/threescale/api/utilities.go
+++ b/threescale/api/utilities.go
@@ -101,6 +101,11 @@ func (m Metrics) DeepCopy() Metrics {
 	return clone
 }
 
+// String returns a string representation of the Period
+func (p Period) String() string {
+	return [...]string{"minute", "hour", "day", "week", "month", "year", "eternity"}[p]
+}
+
 // IsEqual compares two PeriodWindows. They are equal if the period is the same
 // and timestamps for start and end do not differ
 func (pw PeriodWindow) IsEqual(window PeriodWindow) bool {

--- a/threescale/api/utilities.go
+++ b/threescale/api/utilities.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"sort"
 )
 
 // DeepCopy returns a clone of the original Metrics. It provides a deep copy
@@ -127,6 +128,24 @@ func (ur UsageReport) IsSame(usageReport UsageReport) bool {
 	}
 
 	return true
+}
+
+// OrderByAscendingGranularity sorts each slice in the usage reports in order of ascending granularity
+func (urs UsageReports) OrderByAscendingGranularity() {
+	for _, reports := range urs {
+		sort.SliceStable(reports, func(i, j int) bool {
+			return reports[i].PeriodWindow.Period < reports[j].PeriodWindow.Period
+		})
+	}
+}
+
+// OrderByDescendingGranularity sorts each slice in the usage reports in order of descending granularity
+func (urs UsageReports) OrderByDescendingGranularity() {
+	for _, reports := range urs {
+		sort.SliceStable(reports, func(i, j int) bool {
+			return reports[i].PeriodWindow.Period > reports[j].PeriodWindow.Period
+		})
+	}
 }
 
 func contains(key string, in []string) bool {

--- a/threescale/api/utilities_test.go
+++ b/threescale/api/utilities_test.go
@@ -341,3 +341,109 @@ func TestUsageReport_IsSame(t *testing.T) {
 		})
 	}
 }
+
+func TestUsageReports_OrderByAscendingGranularity(t *testing.T) {
+	input := UsageReports{
+		"hits_one": {
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Day,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Eternity,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Month,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Week,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Minute,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Year,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Hour,
+				},
+			},
+		},
+	}
+
+	input.OrderByAscendingGranularity()
+	sorted := input["hits_one"]
+
+	var expect = []string{"minute", "hour", "day", "week", "month", "year", "eternity"}
+
+	for i, value := range sorted {
+		if value.PeriodWindow.Period.String() != expect[i] {
+			t.Errorf("Expected %s but got %s", expect[i], value.PeriodWindow.Period.String())
+		}
+	}
+}
+
+func TestUsageReports_OrderByDescendingGranularity(t *testing.T) {
+	input := UsageReports{
+		"hits_one": {
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Day,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Eternity,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Month,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Week,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Minute,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Year,
+				},
+			},
+			{
+				PeriodWindow: PeriodWindow{
+					Period: Hour,
+				},
+			},
+		},
+	}
+
+	input.OrderByDescendingGranularity()
+	sorted := input["hits_one"]
+
+	var expect = []string{"eternity", "year", "month", "week", "day", "hour", "minute"}
+
+	for i, value := range sorted {
+		if value.PeriodWindow.Period.String() != expect[i] {
+			t.Errorf("Expected %s but got %s", expect[i], value.PeriodWindow.Period.String())
+		}
+	}
+}

--- a/threescale/helpers.go
+++ b/threescale/helpers.go
@@ -6,9 +6,3 @@ import "github.com/3scale/3scale-go-client/threescale/api"
 func (r Request) GetServiceID() api.Service {
 	return r.Service
 }
-
-var ascendingPeriodSequence = []api.Period{api.Minute, api.Hour, api.Day, api.Week, api.Month, api.Eternity}
-
-func GetAscendingPeriodSequence() []api.Period {
-	return ascendingPeriodSequence
-}

--- a/threescale/http/client.go
+++ b/threescale/http/client.go
@@ -342,6 +342,16 @@ func contains(key string, in []string) bool {
 	return false
 }
 
+var granularityMap = map[string]api.Period{
+	"minute":   api.Minute,
+	"hour":     api.Hour,
+	"day":      api.Day,
+	"week":     api.Week,
+	"month":    api.Month,
+	"year":     api.Year,
+	"eternity": api.Eternity,
+}
+
 // convert an xml decoded response into a user friendly UsageReport
 func convertXmlToUsageReport(ur internal.UsageReportXML) (api.UsageReport, error) {
 	var err error
@@ -351,7 +361,7 @@ func convertXmlToUsageReport(ur internal.UsageReportXML) (api.UsageReport, error
 	}
 
 	pw := api.PeriodWindow{
-		Period: ur.Period,
+		Period: granularityMap[ur.Period],
 	}
 
 	parseTime := func(timestamp string) (int64, error) {

--- a/threescale/internal/xml.go
+++ b/threescale/internal/xml.go
@@ -2,8 +2,6 @@ package internal
 
 import (
 	"encoding/xml"
-
-	"github.com/3scale/3scale-go-client/threescale/api"
 )
 
 // AuthResponseXML formatted response from backend API for Authorize and AuthRep
@@ -28,12 +26,12 @@ type HierarchyXML struct {
 
 // UsageReportXML captures the XML response for rate limiting details
 type UsageReportXML struct {
-	Metric       string     `xml:"metric,attr"`
-	Period       api.Period `xml:"period,attr"`
-	PeriodStart  string     `xml:"period_start"`
-	PeriodEnd    string     `xml:"period_end"`
-	MaxValue     int        `xml:"max_value"`
-	CurrentValue int        `xml:"current_value"`
+	Metric       string `xml:"metric,attr"`
+	Period       string `xml:"period,attr"`
+	PeriodStart  string `xml:"period_start"`
+	PeriodEnd    string `xml:"period_end"`
+	MaxValue     int    `xml:"max_value"`
+	CurrentValue int    `xml:"current_value"`
 }
 
 // ReportErrorXML captures the XML response from Report endpoint when not status 202


### PR DESCRIPTION
When 3scale returns its usage reporting information, it is unsorted by default. These changes and helpers allow a caller to sort the lists in both ascending and descending time periods.