### PR TITLE
Updates to Timestamp semantics 

### DIFF
--- a/threescale/api/types.go
+++ b/threescale/api/types.go
@@ -111,9 +111,11 @@ type Service string
 // Transaction holds the params and optional additions that will be sent
 // to 3scale as query parameters or headers.
 type Transaction struct {
-	Metrics   Metrics
-	Params    Params
-	Timestamp string
+	Metrics Metrics
+	Params  Params
+	// Timestamp is a unix timestamp.
+	// Timestamp will only be taken into account when calling the Report API
+	Timestamp int64
 }
 
 // UsageReport for rate limiting information gathered from using extensions

--- a/threescale/helpers.go
+++ b/threescale/helpers.go
@@ -1,8 +1,19 @@
 package threescale
 
-import "github.com/3scale/3scale-go-client/threescale/api"
+import (
+	"time"
+
+	"github.com/3scale/3scale-go-client/threescale/api"
+)
+
+const timeLayout = "2006-01-02 15:04:05 -0700"
 
 // GetServiceID from Request
 func (r Request) GetServiceID() api.Service {
 	return r.Service
+}
+
+// FormatTimestamp from unix time to string formatting as understood by 3scale
+func FormatTimestamp(timestamp int64) string {
+	return time.Unix(timestamp, 0).Format(timeLayout)
 }

--- a/threescale/helpers_test.go
+++ b/threescale/helpers_test.go
@@ -20,3 +20,13 @@ func TestRequest_GetServiceID(t *testing.T) {
 		t.Errorf("expected %s but got %s", expectService, r.GetServiceID())
 	}
 }
+
+func TestFormatTimestamp(t *testing.T) {
+	const expect = "2020-03-10 11:31:31 +0000"
+	timestamp := int64(1583839891)
+	got := FormatTimestamp(timestamp)
+
+	if expect != got {
+		t.Errorf("failed to convert timestamp, wanted %s, but got %s", expect, got)
+	}
+}

--- a/threescale/http/builder.go
+++ b/threescale/http/builder.go
@@ -135,6 +135,10 @@ func (rb requestBuilder) transactionToValues(index int, t api.Transaction) url.V
 	for k, v := range t.Metrics {
 		values.Add(fmt.Sprintf("transactions[%d][usage][%s]", index, k), strconv.Itoa(v))
 	}
+
+	if t.Timestamp != 0 {
+		values.Add(fmt.Sprintf("transactions[%d][timestamp]", index), strconv.FormatInt(t.Timestamp, 10))
+	}
 	return values
 }
 

--- a/threescale/http/client_test.go
+++ b/threescale/http/client_test.go
@@ -616,13 +616,15 @@ func TestClient_Report(t *testing.T) {
 					Params: api.Params{
 						UserKey: "test",
 					},
-					Metrics: api.Metrics{"hits": 1},
+					Metrics:   api.Metrics{"hits": 1},
+					Timestamp: 500,
 				},
 				{
 					Params: api.Params{
 						UserKey: "test-2",
 					},
-					Metrics: api.Metrics{"hits": 1, "other": 2},
+					Metrics:   api.Metrics{"hits": 1, "other": 2},
+					Timestamp: 1000,
 				},
 			},
 			expectResponse: &threescale.ReportResult{
@@ -630,8 +632,8 @@ func TestClient_Report(t *testing.T) {
 			},
 			injectClient: NewTestClient(func(req *http.Request) *http.Response {
 				// we know that Encode will sort by keys so we can predict this output
-				// decoded to service_id=test-id&service_token=st&transactions[0][usage][hits]=1&transactions[0][user_key]=test&transactions[1][usage][hits]=1&transactions[1][usage][other]=2&transactions[1][user_key]=test-2
-				expect := `service_id=test-id&service_token=st&transactions%5B0%5D%5Busage%5D%5Bhits%5D=1&transactions%5B0%5D%5Buser_key%5D=test&transactions%5B1%5D%5Busage%5D%5Bhits%5D=1&transactions%5B1%5D%5Busage%5D%5Bother%5D=2&transactions%5B1%5D%5Buser_key%5D=test-2`
+				// decoded to service_id=test-id&service_token=st&transactions[0][timestamp]=500&transactions[0][usage][hits]=1&transactions[0][user_key]=test&transactions[1][timestamp]=1000&transactions[1][usage][hits]=1&transactions[1][usage][other]=2&transactions[1][user_key]=test-2
+				expect := `service_id=test-id&service_token=st&transactions%5B0%5D%5Btimestamp%5D=500&transactions%5B0%5D%5Busage%5D%5Bhits%5D=1&transactions%5B0%5D%5Buser_key%5D=test&transactions%5B1%5D%5Btimestamp%5D=1000&transactions%5B1%5D%5Busage%5D%5Bhits%5D=1&transactions%5B1%5D%5Busage%5D%5Bother%5D=2&transactions%5B1%5D%5Buser_key%5D=test-2`
 				equals(t, expect, req.URL.RawQuery)
 
 				return &http.Response{


### PR DESCRIPTION
Adds support for reporting with timestamps in report API and changes the exported API timestamp type from string to int64 (related to https://github.com/3scale/apisonator/pull/167 )