### PR TITLE
Support oauth_auth*.xml endpoints

### DIFF
--- a/threescale/client.go
+++ b/threescale/client.go
@@ -14,6 +14,14 @@ type Client interface {
 	// the authentication provided in the transaction params
 	// Where multiple transactions are provided, all but the first should be discarded
 	AuthRep(request Request) (*AuthorizeResult, error)
+	// DEPRECATED - DO NOT USE in new code. Work around for versions
+	// of 3scale before 2.11 where OIDC applications needed to call
+	// the oauth_auth*.xml endpoints.
+	OauthAuthorize(request Request) (*AuthorizeResult, error)
+	// DEPRECATED - DO NOT USE in new code. Work around for versions
+	// of 3scale before 2.11 where OIDC applications needed to call
+	// the oauth_auth*.xml endpoints.
+	OauthAuthRep(request Request) (*AuthorizeResult, error)
 	// Report the transactions to 3scale backend with the authentication provided in the transactions params
 	Report(request Request) (*ReportResult, error)
 	// GetPeer returns the hostname of the connected backend

--- a/threescale/http/builder.go
+++ b/threescale/http/builder.go
@@ -81,6 +81,10 @@ func (rb requestBuilder) kindToHTTPRequest(baseURL string, kind kind) (*http.Req
 		return http.NewRequest(http.MethodGet, baseURL+authRepEndpoint, nil)
 	case report:
 		return http.NewRequest(http.MethodPost, baseURL+reportEndpoint, nil)
+	case oauthAuth:
+		return http.NewRequest(http.MethodGet, baseURL+oauthAuthzEndpoint, nil)
+	case oauthAuthRep:
+		return http.NewRequest(http.MethodGet, baseURL+oauthAuthRepEndpoint, nil)
 	default:
 		return nil, fmt.Errorf("unknown api call kind provided")
 	}

--- a/threescale/http/client.go
+++ b/threescale/http/client.go
@@ -18,7 +18,9 @@ import (
 
 const (
 	authzEndpoint   = "/transactions/authorize.xml"
+	oauthAuthzEndpoint = "/transactions/oauth_authorize.xml"
 	authRepEndpoint = "/transactions/authrep.xml"
+	oauthAuthRepEndpoint = "/transactions/oauth_authrep.xml"
 	reportEndpoint  = "/transactions.xml"
 
 	statusEndpoint = "/status"
@@ -91,6 +93,16 @@ func (c *Client) AuthorizeWithOptions(apiCall threescale.Request, options ...Opt
 	return c.doAuthOrAuthRep(apiCall, auth, newOptions(options...))
 }
 
+// Deprecated - DO NOT use in new code.
+func (c *Client) OauthAuthorize(apiCall threescale.Request) (*threescale.AuthorizeResult, error) {
+	return c.OauthAuthorizeWithOptions(apiCall)
+}
+
+// Deprecated - DO NOT use in new code.
+func (c *Client) OauthAuthorizeWithOptions(apiCall threescale.Request, options ...Option) (*threescale.AuthorizeResult, error) {
+	return c.doAuthOrAuthRep(apiCall, oauthAuth, newOptions(options...))
+}
+
 // AuthRep should be used to authorize and report, in a single transaction
 // for an application with the authentication provided in the transaction params
 func (c *Client) AuthRep(apiCall threescale.Request) (*threescale.AuthorizeResult, error) {
@@ -100,6 +112,16 @@ func (c *Client) AuthRep(apiCall threescale.Request) (*threescale.AuthorizeResul
 // AuthRepWithOptions provides the same behaviour as AuthRep with additional functionality provided by Option(s)
 func (c *Client) AuthRepWithOptions(apiCall threescale.Request, options ...Option) (*threescale.AuthorizeResult, error) {
 	return c.doAuthOrAuthRep(apiCall, authRep, newOptions(options...))
+}
+
+// Deprecated - DO NOT use in new code.
+func (c *Client) OauthAuthRep(apiCall threescale.Request) (*threescale.AuthorizeResult, error) {
+	return c.OauthAuthRepWithOptions(apiCall)
+}
+
+// Deprecated - DO NOT use in new code.
+func (c *Client) OauthAuthRepWithOptions(apiCall threescale.Request, options ...Option) (*threescale.AuthorizeResult, error) {
+	return c.doAuthOrAuthRep(apiCall, oauthAuthRep, newOptions(options...))
 }
 
 func (c *Client) Report(apiCall threescale.Request) (*threescale.ReportResult, error) {
@@ -408,6 +430,9 @@ const (
 	auth kind = iota
 	authRep
 	report
+	// DO NOT use the below kinds in any new code - they are deprecated
+	oauthAuth
+	oauthAuthRep
 )
 
 // Verifies a custom backend is valid


### PR DESCRIPTION
These endpoints should be considered deprecated in the next release via an updated Apisonator version, but older releases need to access them to report OIDC apps without needing an `app_key=${client_secret}` parameter. Details are subtle and you can learn more at https://github.com/3scale/apisonator/pull/280.